### PR TITLE
Add red preset

### DIFF
--- a/po/bedtime-mode.pot
+++ b/po/bedtime-mode.pot
@@ -37,6 +37,10 @@ msgstr ""
 msgid "Sepia"
 msgstr ""
 
+#: src/modules/Presets.js:39
+msgid "Red"
+msgstr ""
+
 #: src/modules/QuickSetting.js:18 src/modules/QuickSetting.js:19
 msgid "Bedtime Mode"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -38,6 +38,10 @@ msgstr "Azurová"
 msgid "Sepia"
 msgstr "Sépiová"
 
+#: src/modules/Presets.js:39
+msgid "Red"
+msgstr "Červená"
+
 #: src/modules/QuickSetting.js:18 src/modules/QuickSetting.js:19
 msgid "Bedtime Mode"
 msgstr "Režim večerky"

--- a/po/de.po
+++ b/po/de.po
@@ -38,6 +38,10 @@ msgstr "Cyan"
 msgid "Sepia"
 msgstr "Sepia"
 
+#: src/modules/Presets.js:39
+msgid "Red"
+msgstr "Rot"
+
 #: src/modules/QuickSetting.js:18 src/modules/QuickSetting.js:19
 msgid "Bedtime Mode"
 msgstr "Schlafenszeitmodus"

--- a/po/es.po
+++ b/po/es.po
@@ -38,6 +38,10 @@ msgstr "Cian"
 msgid "Sepia"
 msgstr "Sepia"
 
+#: src/modules/Presets.js:39
+msgid "Red"
+msgstr "Rojo"
+
 #: src/modules/QuickSetting.js:18 src/modules/QuickSetting.js:19
 msgid "Bedtime Mode"
 msgstr "Modo descanso"

--- a/po/nl.po
+++ b/po/nl.po
@@ -39,6 +39,10 @@ msgstr "Groenblauw"
 msgid "Sepia"
 msgstr "Sepia"
 
+#: src/modules/Presets.js:39
+msgid "Red"
+msgstr "Rood"
+
 #: src/modules/QuickSetting.js:18 src/modules/QuickSetting.js:19
 msgid "Bedtime Mode"
 msgstr "Nachtkastmodus"

--- a/po/ro.po
+++ b/po/ro.po
@@ -38,6 +38,10 @@ msgstr "Turcoaz"
 msgid "Sepia"
 msgstr "Sepia"
 
+#: src/modules/Presets.js:39
+msgid "Red"
+msgstr "Roșu"
+
 #: src/modules/QuickSetting.js:18 src/modules/QuickSetting.js:19
 msgid "Bedtime Mode"
 msgstr "Mod Ora de culcare"

--- a/src/modules/Presets.js
+++ b/src/modules/Presets.js
@@ -34,4 +34,10 @@ var ColorTones = [
     brightness: { red: 143, green: 127, blue: 95, alpha: 255 },
     contrast: { red: 143, green: 127, blue: 127, alpha: 255 },
   },
+  {
+    id: "red",
+    displayName: _("Red"),
+    brightness: { red: 127, green: 0, blue: 0, alpha: 255 },
+    contrast: { red: 127, green: 127, blue: 127, alpha: 255 },
+  }
 ];


### PR DESCRIPTION
Hi, 

this PR adds a red color scheme to the presets. This is especially helpful when doing visual astronomy observations at night. I also added the translations (using Deepl :D). Would you have a look at it?

br, Christian